### PR TITLE
Add Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - name: Install Nextflow
+    init: |
+      curl -s https://get.nextflow.io | bash
+      sudo mv nextflow /usr/local/bin


### PR DESCRIPTION
Adds configuration for a Gitpod. 
- Gitpod already has docker ( in docker ) installed, as well as java.
- Config installs Nextflow. 

Allows anyone from anywhere to spin up an instance of this course and learn at their own pace.
Default software should therefore be pulled using Docker containers rather than from a conda environment.

Prefix the repository with https://gitpod.io/#
E.g. https://gitpod.io/#https://github.com/mahesh-panchal/workflows-nextflow
A terminal can be started from VScode, giving learners a fully integrated IDE.