### PR TITLE
Remove overcomplicated Gitpod extensions

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,14 +1,7 @@
 image: nfcore/gitpod:latest
 
 vscode:
-  extensions: # based on nf-core.nf-core-extensionpack
-    - codezombiech.gitignore                 # Language support for .gitignore files
-    # - cssho.vscode-svgviewer                 # SVG viewer
-    - davidanson.vscode-markdownlint         # Markdown/CommonMark linting and style checking for Visual Studio Code
-    - eamodio.gitlens                        # Quickly glimpse into whom, why, and when a line or code block was changed
-    - EditorConfig.EditorConfig              # override user/workspace settings with settings found in .editorconfig files
-    - Gruntfuggly.todo-tree                  # Display TODO and FIXME in a tree view in the activity bar
-    - mechatroner.rainbow-csv                # Highlight columns in csv files in different colors
+  extensions: # minimal helpful extensions from nf-core suggestions.
     # - nextflow.nextflow                      # Nextflow syntax highlighting
     - oderwat.indent-rainbow                 # Highlight indentation level
     - streetsidesoftware.code-spell-checker  # Spelling checker for source code


### PR DESCRIPTION
The default nf-core gitpod config has a lot of extensions enabled. 
They're reduced here to minimize the distractions for learners, keeping only what is useful.