### PR TITLE
Update 02-workflow_parameters.md for script name consistency

### DIFF
--- a/episodes/02-workflow_parameters.md
+++ b/episodes/02-workflow_parameters.md
@@ -133,7 +133,7 @@ Let's make a copy of the `word_count.nf` script as `wc-params.nf` and add a new
 input parameter.
 
 ``` bash
-$ cp wc.nf wc-params.nf
+$ cp word_count.nf wc-params.nf
 ```
 
 To add a parameter `sleep` with the default value `2` to `wc-params.nf`


### PR DESCRIPTION
wc.nf in the given bash script would ideally be word_count.nf to ensure consistency within the text and allow a straight copy-paste