### PR TITLE
Fix input qualifier for the QUANT step and minor typo in the page

### DIFF
--- a/episodes/11-Simple_Rna-Seq_pipeline.md
+++ b/episodes/11-Simple_Rna-Seq_pipeline.md
@@ -489,7 +489,7 @@ The script `script4.nf`;
 process QUANT {
 
     input:
-    path index
+    each index
     tuple val(pair_id), path(reads)
 
     output:
@@ -731,7 +731,7 @@ ch1.collect().view()
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 
-## Combing operators
+## Combining operators
 
 Which is the correct way to combined `mix` and `collect` operators so that you have a single channel with one List item?
 


### PR DESCRIPTION
The original input qualifier for index ("path") would only run one sample, changing it to "each" will run all samples when running the Nextflow file.